### PR TITLE
Accept non standard layout of columns from top's output

### DIFF
--- a/src/parser/CpuUsageParser.tsx
+++ b/src/parser/CpuUsageParser.tsx
@@ -77,7 +77,7 @@ export default class CpuUsageParser {
       .slice(2)
       .filter((line) => line)
       .map((line) => matchMultipleTimes(COLUMN_MATCHER, line))
-      .filter((columns) => columns.length >= 11)
+      .filter((columns) => columns.length >= offsets.getMaxIndex())
       .forEach((columns) => {
         const id = parseInt(columns[offsets.getProcessIdOffset()], 10);
         const cpuUsage = parseFloat(columns[offsets.getCpuUsageOffset()]);

--- a/src/parser/TopColumnOffsets.tsx
+++ b/src/parser/TopColumnOffsets.tsx
@@ -28,4 +28,8 @@ export default class TopColumnOffsets {
   public setRunningForOffset(offset: number): void {
     this.runningFor = offset;
   }
+
+  public getMaxIndex() {
+    return Math.max(this.id, this.cpuUsage, this.runningFor);
+  }
 }


### PR DESCRIPTION
This change should allow Watson to analyze top's outputs that use different set of columns but include the mandatory ones (PID, %CPU, TIME+)