### PR TITLE
Adding Dockerfile for easier local running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18.17.0-bullseye-slim
+
+EXPOSE 3000
+
+WORKDIR /opt/app
+
+COPY --chown=node:node package.json yarn.lock /opt/app
+RUN cd /opt/app \
+     && yarn install --pure-lockfile
+
+COPY --chown=node:node . /opt/app
+
+USER node
+
+CMD yarn start


### PR DESCRIPTION
This adds a basic Dockerfile to allow Watson to more easily be run locally by customers who wouldn't want to submit their thread dumps to drauf.github.io/watson.