### PR TITLE
Use a more extensive tomcat thread pattern

### DIFF
--- a/src/components/ThreadsOverview/ThreadsOverviewPage.tsx
+++ b/src/components/ThreadsOverview/ThreadsOverviewPage.tsx
@@ -37,7 +37,7 @@ class ThreadsOverviewPage extends PageWithSettings<WithThreadDumpsProps, State> 
 
   private jvmRegex = /^Attach Listener|^C[12] CompilerThread|^G1 Concurrent |^G1 Main|^Gang worker#|^GC Daemon|^Service Thread|^Signal Dispatcher|^String Deduplication Thread|^Surrogate Locker Thread|^VM Periodic|^VM Thread/;
 
-  private tomcatRegex = /^http(s-jsse)?-[a-z]io-[0-9]+-exec-[0-9]+/;
+  private tomcatRegex = /^(http|https|ajp)[\w]*-([a-z0-9.]+-)+exec-[0-9]+/;
 
   private databaseRegex = /^oracle\.jdbc\.driver\.|^org\.postgresql\.|^com\.microsoft\.sqlserver\.|^com\.mysql\.jdbc\./;
 


### PR DESCRIPTION
The current pattern misses various patterns, e.g. `ajp-nio-0.0.0.0-8600-exec-977` or `https-jsse-apr-localhost-8443-exec-1003`