### PR TITLE
Fix thread dump ordering across midnight

### DIFF
--- a/src/parser/AsyncParser.test.tsx
+++ b/src/parser/AsyncParser.test.tsx
@@ -11,6 +11,7 @@ import {
 } from 'vitest';
 import AsyncParser, { ProgressCallback, CompletionCallback } from './AsyncParser';
 import ThreadDump from '../types/ThreadDump';
+import CpuUsage from './cpuusage/CpuUsage';
 
 // Mock the AsyncThreadDumpParser
 vi.mock('./AsyncThreadDumpParser', () => ({
@@ -32,7 +33,7 @@ vi.mock('./cpuusage/jfr/CpuUsageJfrParser', () => ({
   default: {
     parseCpuUsage: vi.fn(),
   },
-  CPU_USAGE_JFR_FIRST_LINE_PATTERN: /^"Thread Name"/,
+  CPU_USAGE_JFR_FIRST_LINE_PATTERN: /^(JVM_THREAD_ID\s*OS_THREAD_ID\s*%CPU_USER_MODE\s*%CPU_SYSTEM_MODE\s*SYSTEM_TIME\s*THREAD_NAME)/,
 }));
 
 describe('AsyncParser', () => {
@@ -129,6 +130,57 @@ describe('AsyncParser', () => {
       ]));
     });
 
+    it('matches JFR CPU usage with the same absolute filename timestamp', async () => {
+      const firstThreadDumpFile = createMockFile(
+        '2026_07_22_09_13_46.txt',
+        '2026-07-22 09:13:46\n"Thread-1" #1 prio=5 tid=0x1 nid=0x1',
+      );
+      const secondThreadDumpFile = createMockFile(
+        '2026_07_22_10_13_46.txt',
+        '2026-07-22 10:13:46\n"Thread-2" #2 prio=5 tid=0x2 nid=0x2',
+      );
+      const cpuUsageFile = createMockFile(
+        '2026_07_22_10_13_46_thread_cpu_utilisation.txt',
+        'JVM_THREAD_ID OS_THREAD_ID %CPU_USER_MODE %CPU_SYSTEM_MODE SYSTEM_TIME THREAD_NAME',
+      );
+
+      const AsyncThreadDumpParser = await import('./AsyncThreadDumpParser');
+      (AsyncThreadDumpParser.default.parseThreadDump as any).mockImplementation(
+        (_lines: string[], callback: any, _progress: any, _config: any, epochFromFileName: number) => {
+          const threadDump = new ThreadDump(epochFromFileName);
+          threadDump.threads.push({ id: epochFromFileName, name: 'Thread' } as any);
+          callback(threadDump);
+          return Promise.resolve();
+        },
+      );
+
+      const CpuUsageJfrParser = await import('./cpuusage/jfr/CpuUsageJfrParser');
+      (CpuUsageJfrParser.default.parseCpuUsage as any).mockImplementation(
+        (fileName: string, _lines: string[], callback: any) => {
+          callback(CpuUsage.fromJfr(fileName, 7, []));
+        },
+      );
+
+      await parser.parseFiles([firstThreadDumpFile, secondThreadDumpFile, cpuUsageFile]);
+
+      const parsedThreadDumps = (mockOnFilesParsed as any).mock.calls[0][0] as ThreadDump[];
+      expect(parsedThreadDumps).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          epoch: Date.UTC(2026, 6, 22, 10, 13, 46),
+          runningProcesses: 7,
+        }),
+      ]));
+      expect(parsedThreadDumps).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          epoch: Date.UTC(2026, 6, 22, 9, 13, 46),
+        }),
+      ]));
+      const firstThreadDump = parsedThreadDumps.find(
+        (threadDump) => threadDump.epoch === Date.UTC(2026, 6, 22, 9, 13, 46),
+      );
+      expect(firstThreadDump?.runningProcesses).toBeUndefined();
+    });
+
     it('should handle multiple files', async () => {
       const file1 = createMockFile('dump1.txt', '2023-01-01 12:00:00\n"Thread-1" #1 prio=5 tid=0x1 nid=0x1');
       const file2 = createMockFile('dump2.txt', '2023-01-01 12:01:00\n"Thread-2" #2 prio=5 tid=0x2 nid=0x2');
@@ -159,16 +211,16 @@ describe('AsyncParser', () => {
 
       // Mock FileReader to simulate error
       const originalFileReader = global.FileReader;
-      global.FileReader = vi.fn().mockImplementation(() => ({
-        readAsText: vi.fn().mockImplementation(function (this: any) {
+      global.FileReader = vi.fn().mockImplementation(function (this: any) {
+        this.readAsText = vi.fn().mockImplementation(function (this: any) {
           // Simulate error
           setTimeout(() => {
             if (this.onerror) {
               this.onerror(new Error('File read error'));
             }
           }, 0);
-        }),
-      })) as any;
+        });
+      }) as any;
 
       await expect(parser.parseFiles([file])).rejects.toThrow();
 

--- a/src/parser/AsyncParser.tsx
+++ b/src/parser/AsyncParser.tsx
@@ -1,4 +1,5 @@
 import CpuUsage from './cpuusage/CpuUsage';
+import { tryGetEpochFromFileName } from './TimestampParser';
 import Thread from '../types/Thread';
 import ThreadDump from '../types/ThreadDump';
 import TopCpuUsageParser, { CPU_USAGE_TIMESTAMP_PATTERN } from './cpuusage/os/TopCpuUsageParser';
@@ -113,7 +114,7 @@ export default class AsyncParser {
           } else if (matchOne(CPU_USAGE_JFR_FIRST_LINE_PATTERN, firstLine)) {
             this.parseJfrCpuUsage(file.name, lines);
           } else {
-            await this.splitThreadDumpsAsync(lines);
+            await this.splitThreadDumpsAsync(lines, tryGetEpochFromFileName(file.name));
           }
 
           resolve();
@@ -127,7 +128,10 @@ export default class AsyncParser {
     });
   }
 
-  private async splitThreadDumpsAsync(lines: string[]): Promise<void> {
+  private async splitThreadDumpsAsync(lines: string[], epochFromFileName?: number): Promise<void> {
+    const threadDumpCount = lines.filter((line) => matchOne(THREAD_DUMP_DATE_PATTERN, line)).length;
+    // One filename timestamp cannot identify multiple dumps in the same file
+    const epochFromFileNameForSingleDump = threadDumpCount === 1 ? epochFromFileName : undefined;
     let currentDump: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
@@ -140,7 +144,7 @@ export default class AsyncParser {
           currentDump.push(line);
         } else {
           // eslint-disable-next-line no-await-in-loop
-          await this.parseThreadDumpAsync(currentDump);
+          await this.parseThreadDumpAsync(currentDump, epochFromFileNameForSingleDump);
           currentDump = [line];
         }
       } else if (currentDump.length > 0) {
@@ -150,7 +154,7 @@ export default class AsyncParser {
     }
 
     if (currentDump.length > 0) {
-      await this.parseThreadDumpAsync(currentDump);
+      await this.parseThreadDumpAsync(currentDump, epochFromFileNameForSingleDump);
     }
   }
 
@@ -168,7 +172,7 @@ export default class AsyncParser {
     this.cpuUsages.push(cpuUsage);
   };
 
-  private async parseThreadDumpAsync(lines: string[]): Promise<void> {
+  private async parseThreadDumpAsync(lines: string[], epochFromFileName?: number): Promise<void> {
     await AsyncThreadDumpParser.parseThreadDump(
       lines.slice(),
       this.onParsedThreadDump,
@@ -177,6 +181,7 @@ export default class AsyncParser {
         await this.reportProgressAndRefreshUi('parsing', processed, total);
       },
       this.config,
+      epochFromFileName,
     );
   }
 
@@ -226,7 +231,10 @@ export default class AsyncParser {
           return;
         }
 
-        const diff = Math.abs((dumpEpoch % AN_HOUR) - (cpuUsageEpoch % AN_HOUR));
+        // JFR CPU files have an absolute filename timestamp; legacy top data only has a clock time.
+        const diff = cpuUsage.timestampKind === 'absolute'
+          ? Math.abs(dumpEpoch - cpuUsageEpoch)
+          : Math.abs((dumpEpoch % AN_HOUR) - (cpuUsageEpoch % AN_HOUR));
 
         if (diff < smallestDiff) {
           smallestDiff = diff;

--- a/src/parser/AsyncThreadDumpParser.tsx
+++ b/src/parser/AsyncThreadDumpParser.tsx
@@ -26,8 +26,12 @@ export default class AsyncThreadDumpParser {
     callback: ParseThreadDumpCallback,
     progressCallback?: ProgressCallback,
     config: PerformanceConfig = DEFAULT_PERFORMANCE_CONFIG,
+    epochFromFileName?: number,
   ): Promise<void> {
-    const threadDump = ThreadDump.from(matchOne(THREAD_DUMP_DATE_PATTERN, lines.shift() as string));
+    const threadDump = ThreadDump.from(
+      matchOne(THREAD_DUMP_DATE_PATTERN, lines.shift() as string),
+      epochFromFileName,
+    );
     let currentThread: Thread | null = null;
 
     // Process lines in chunks to avoid blocking the UI

--- a/src/parser/TimestampParser.test.tsx
+++ b/src/parser/TimestampParser.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getEpochFromDateTime, tryGetEpochFromFileName } from './TimestampParser';
+
+describe('TimestampParser', () => {
+  it('parses an absolute timestamp from a thread dump file name', () => {
+    expect(tryGetEpochFromFileName('2026_07_22_10_13_46.txt')).toBe(
+      Date.UTC(2026, 6, 22, 10, 13, 46),
+    );
+  });
+
+  it('parses an absolute timestamp from a CPU usage file name', () => {
+    expect(tryGetEpochFromFileName('2026_07_22_10_13_46_thread_cpu_utilisation.txt')).toBe(
+      Date.UTC(2026, 6, 22, 10, 13, 46),
+    );
+  });
+
+  it('returns undefined for a file name without a timestamp', () => {
+    expect(tryGetEpochFromFileName('CPU-USAGE-DUMP-1.txt')).toBeUndefined();
+  });
+
+  it('parses a date and time from thread dump content', () => {
+    expect(getEpochFromDateTime('2026-07-22 10:13:46')).toBe(
+      Date.UTC(2026, 6, 22, 10, 13, 46),
+    );
+  });
+});

--- a/src/parser/TimestampParser.tsx
+++ b/src/parser/TimestampParser.tsx
@@ -1,0 +1,37 @@
+const FILE_NAME_TIMESTAMP_PATTERN = /^(\d{4})_(\d{2})_(\d{2})_(\d{2})_(\d{2})_(\d{2})(?:_thread_cpu_utilisation)?\.txt$/;
+
+const getEpoch = (
+  year: string,
+  month: string,
+  day: string,
+  hours: string,
+  minutes: string,
+  seconds: string,
+): number => Date.UTC(
+  parseInt(year, 10),
+  parseInt(month, 10) - 1,
+  parseInt(day, 10),
+  parseInt(hours, 10),
+  parseInt(minutes, 10),
+  parseInt(seconds, 10),
+);
+
+export const tryGetEpochFromFileName = (fileName: string): number | undefined => {
+  const match = FILE_NAME_TIMESTAMP_PATTERN.exec(fileName);
+  if (match === null) {
+    return undefined;
+  }
+
+  const [, year, month, day, hours, minutes, seconds] = match;
+  return getEpoch(year, month, day, hours, minutes, seconds);
+};
+
+// Parse YYYY-MM-DD HH:mm:ss explicitly because Safari does not reliably parse this timestamp format
+export const getEpochFromDateTime = (dateTime: string): number => getEpoch(
+  dateTime.substring(0, 4),
+  dateTime.substring(5, 7),
+  dateTime.substring(8, 10),
+  dateTime.substring(11, 13),
+  dateTime.substring(14, 16),
+  dateTime.substring(17),
+);

--- a/src/parser/cpuusage/CpuUsage.test.tsx
+++ b/src/parser/cpuusage/CpuUsage.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import LoadAverages from '../../types/LoadAverage';
+import MemoryUnit from '../../types/MemoryUnit';
+import MemoryUsage from '../../types/MemoryUsage';
+import CpuUsage from './CpuUsage';
+
+describe('CpuUsage', () => {
+  it('uses an absolute timestamp for JFR CPU usage files', () => {
+    const cpuUsage = CpuUsage.fromJfr(
+      '2026_07_22_10_13_46_thread_cpu_utilisation.txt',
+      0,
+      [],
+    );
+
+    expect(cpuUsage.timestampKind).toBe('absolute');
+    expect(cpuUsage.epoch).toBe(Date.UTC(2026, 6, 22, 10, 13, 46));
+  });
+
+  it('uses a time-of-day timestamp for top output', () => {
+    const cpuUsage = CpuUsage.fromTop(
+      '09:50:49',
+      0,
+      [],
+      new LoadAverages(0, 0, 0),
+      new MemoryUsage(0, 0, 0, 0, 0, 0, MemoryUnit.KiB),
+    );
+
+    expect(cpuUsage.timestampKind).toBe('time-of-day');
+    expect(cpuUsage.epoch).toBe(35449000);
+  });
+});

--- a/src/parser/cpuusage/CpuUsage.tsx
+++ b/src/parser/cpuusage/CpuUsage.tsx
@@ -1,9 +1,14 @@
 import LoadAverages from '../../types/LoadAverage';
 import MemoryUsage from '../../types/MemoryUsage';
 import ThreadCpuUsage from './ThreadCpuUsage';
+import { tryGetEpochFromFileName } from '../TimestampParser';
+
+export type CpuUsageTimestampKind = 'absolute' | 'time-of-day';
 
 export default class CpuUsage {
   public readonly epoch: number;
+
+  public readonly timestampKind: CpuUsageTimestampKind;
 
   public readonly runningProcesses: number;
 
@@ -13,17 +18,13 @@ export default class CpuUsage {
 
   public readonly memoryUsage?: MemoryUsage;
 
-  private static calculateEpochFromFilename(fileName: string): number {
-    // filename has a format of yyyy_mm_dd_hh_mm_ss_thread_cpu_utilisation.txt
-    const hours = parseInt(fileName.substring(11, 13), 10);
-    const minutes = parseInt(fileName.substring(14, 16), 10);
-    const seconds = parseInt(fileName.substring(17, 19), 10);
-
-    return hours * 3600000 + minutes * 60000 + seconds * 1000;
-  }
-
   public static fromJfr(fileName: string, runningProcesses: number, threadCpuUsages: ThreadCpuUsage[]): CpuUsage {
-    return new CpuUsage(CpuUsage.calculateEpochFromFilename(fileName), runningProcesses, threadCpuUsages);
+    return new CpuUsage(
+      tryGetEpochFromFileName(fileName) ?? 0,
+      'absolute',
+      runningProcesses,
+      threadCpuUsages,
+    );
   }
 
   private static calculateEpochFromTimestamp(timestamp: string): number {
@@ -36,11 +37,26 @@ export default class CpuUsage {
   }
 
   public static fromTop(timestamp: string, runningProcesses: number, threadCpuUsages: ThreadCpuUsage[], loadAverages: LoadAverages, memoryUsage: MemoryUsage): CpuUsage {
-    return new CpuUsage(CpuUsage.calculateEpochFromTimestamp(timestamp), runningProcesses, threadCpuUsages, loadAverages, memoryUsage);
+    return new CpuUsage(
+      CpuUsage.calculateEpochFromTimestamp(timestamp),
+      'time-of-day',
+      runningProcesses,
+      threadCpuUsages,
+      loadAverages,
+      memoryUsage,
+    );
   }
 
-  private constructor(epoch: number, runningProcesses: number, threadCpuUsages: ThreadCpuUsage[], loadAverages?: LoadAverages, memoryUsage?: MemoryUsage) {
+  private constructor(
+    epoch: number,
+    timestampKind: CpuUsageTimestampKind,
+    runningProcesses: number,
+    threadCpuUsages: ThreadCpuUsage[],
+    loadAverages?: LoadAverages,
+    memoryUsage?: MemoryUsage,
+  ) {
     this.epoch = epoch;
+    this.timestampKind = timestampKind;
     if (loadAverages !== undefined) {
       this.loadAverages = loadAverages;
     }

--- a/src/parser/cpuusage/os/TopCpuUsageParser.test.tsx
+++ b/src/parser/cpuusage/os/TopCpuUsageParser.test.tsx
@@ -91,6 +91,8 @@ describe('TopCpuUsageParser', () => {
       'KiB Swap:        0 total,        0 free,        0 used. 44042408 avail Mem',
     );
 
+    expect(cpuUsage.timestampKind).toBe('time-of-day');
+    expect(cpuUsage.epoch).toBe(4400000);
     expect(cpuUsage.runningProcesses).toBe(1);
     expect(cpuUsage.loadAverages?.oneMinute).toBe(1.58);
     expect(cpuUsage.loadAverages?.fiveMinutes).toBe(1.84);

--- a/src/types/ThreadDump.test.tsx
+++ b/src/types/ThreadDump.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import ThreadDump from './ThreadDump';
+
+describe('ThreadDump', () => {
+  it('preserves chronological order across midnight', () => {
+    const beforeMidnight = ThreadDump.from('2026-07-22 23:58:00');
+    const afterMidnight = ThreadDump.from('2026-07-23 00:01:00');
+
+    expect(afterMidnight.epoch).toBeGreaterThan(beforeMidnight.epoch);
+  });
+
+  it('prefers a timestamp from the file name over content', () => {
+    const threadDump = ThreadDump.from(
+      '2026-07-22 10:13:45',
+      Date.UTC(2026, 6, 22, 10, 13, 46),
+    );
+
+    expect(threadDump.epoch).toBe(Date.UTC(2026, 6, 22, 10, 13, 46));
+  });
+});

--- a/src/types/ThreadDump.tsx
+++ b/src/types/ThreadDump.tsx
@@ -2,19 +2,16 @@ import LoadAverages from './LoadAverage';
 import Lock from './Lock';
 import MemoryUsage from './MemoryUsage';
 import Thread from './Thread';
+import { getEpochFromDateTime } from '../parser/TimestampParser';
 
 export default class ThreadDump {
   public static getFormattedTime = (threadDump: ThreadDump): string => (
     new Date(threadDump.epoch).toUTCString().substr(17, 8)
   );
 
-  public static from = (date: string): ThreadDump => {
-    // we can't use new Date(date).valueOf() due to Safari not understanding the date format
-    const hours = parseInt(date.substring(11, 13), 10);
-    const minutes = parseInt(date.substring(14, 16), 10);
-    const seconds = parseInt(date.substring(17), 10);
-    return new ThreadDump(hours * 3600000 + minutes * 60000 + seconds * 1000);
-  };
+  public static from = (dateFromContent: string, epochFromFileName?: number): ThreadDump => (
+    new ThreadDump(epochFromFileName ?? getEpochFromDateTime(dateFromContent))
+  );
 
   public readonly epoch: number;
 


### PR DESCRIPTION
Match timestamped JFR CPU files to thread dumps by full filename time, while retaining clock-only matching for legacy top output.