### PR TITLE
Improve Threads overview rendering boundaries and popup lifecycle

### DIFF
--- a/src/common/getThreadsOverTime.tsx
+++ b/src/common/getThreadsOverTime.tsx
@@ -1,10 +1,11 @@
 import Thread from '../types/Thread';
 import ThreadDump from '../types/ThreadDump';
 
-const getThreadName = (threads: Map<number, Thread>): string => {
-  const firstThread = Array.from(threads.values()).find((thread) => (thread));
-  return firstThread ? firstThread.name : '';
-};
+const getFirstThread = (threads: Map<number, Thread>): Thread | undefined => threads.values().next().value;
+
+const getThreadName = (threads: Map<number, Thread>): string => getFirstThread(threads)?.name || '';
+
+const getThreadId = (threads: Map<number, Thread>): number => getFirstThread(threads)?.id || 0;
 
 export default function getThreadsOverTime(threadDumps: ThreadDump[]): Map<number, Thread>[] {
   const threadsOverTime = new Map<number, Map<number, Thread>>();
@@ -22,5 +23,5 @@ export default function getThreadsOverTime(threadDumps: ThreadDump[]): Map<numbe
   });
 
   return Array.from(threadsOverTime.values())
-    .sort((t1, t2) => getThreadName(t1).localeCompare(getThreadName(t2)));
+    .sort((first, second) => getThreadName(first).localeCompare(getThreadName(second)) || getThreadId(first) - getThreadId(second));
 }

--- a/src/common/threadFilters.tsx
+++ b/src/common/threadFilters.tsx
@@ -17,7 +17,7 @@ import ThreadStatus from '../types/ThreadStatus';
  * @param threadTimeSeries Same thread sampled across multiple dumps
  * @returns true if thread should be shown in timeline analysis
  */
-export function isActiveOverTime(threadTimeSeries: Map<number, Thread>): boolean {
+export function isActiveOverTime(threadTimeSeries: ReadonlyMap<number, Thread>): boolean {
   let previousStatus: ThreadStatus | undefined;
 
   for (const thread of threadTimeSeries.values()) {

--- a/src/components/ThreadDetails/useOpenThreadDetails.test.tsx
+++ b/src/components/ThreadDetails/useOpenThreadDetails.test.tsx
@@ -1,0 +1,32 @@
+import {
+  afterEach, describe, expect, it, vi,
+} from 'vitest';
+import Thread from '../../types/Thread';
+import { openThreadDetailsPopup } from './useOpenThreadDetails';
+
+describe('openThreadDetailsPopup', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns null when the browser blocks the popup', () => {
+    vi.spyOn(window, 'open').mockReturnValue(null);
+
+    expect(openThreadDetailsPopup(new Thread(1, 'worker'))).toBeNull();
+  });
+
+  it('initializes the popup document for the requested thread', () => {
+    const popupDocument = document.implementation.createHTMLDocument('previous title');
+    popupDocument.body.append('previous content');
+    const popup = { document: popupDocument } as Window;
+    const open = vi.spyOn(window, 'open').mockReturnValue(popup);
+    const thread = new Thread(1, 'worker', Date.UTC(2026, 0, 1, 10, 0, 0));
+
+    const result = openThreadDetailsPopup(thread);
+
+    expect(open).toHaveBeenCalledWith('', '_blank', expect.stringContaining('width=960'));
+    expect(open).toHaveBeenCalledWith('', '_blank', expect.stringContaining('height=700'));
+    expect(popupDocument.title).toBe('10:00:00 - worker');
+    expect(popupDocument.body.children).toHaveLength(1);
+    expect(result?.popup).toBe(popup);
+    expect(result?.container).toBe(popupDocument.body.firstElementChild);
+  });
+});

--- a/src/components/ThreadDetails/useOpenThreadDetails.tsx
+++ b/src/components/ThreadDetails/useOpenThreadDetails.tsx
@@ -17,11 +17,26 @@ const popupFeatures = [
   'status=no',
 ].join(',');
 
+export interface ThreadDetailsPopupWindow {
+  popup: Window;
+  container: HTMLElement;
+}
+
+export const openThreadDetailsPopup = (thread: Thread): ThreadDetailsPopupWindow | null => {
+  const popup = window.open('', '_blank', popupFeatures);
+  if (!popup) return null;
+
+  popup.document.title = `${Thread.getFormattedTime(thread)} - ${thread.name}`;
+  const container = popup.document.createElement('div');
+  popup.document.body.replaceChildren(container);
+  return { popup, container };
+};
+
 export default function useOpenThreadDetails(thread: Thread | undefined) {
-  const [popup, setPopup] = useState<{ window: Window; container: HTMLElement } | null>(null);
+  const [popup, setPopup] = useState<ThreadDetailsPopupWindow | null>(null);
 
   const close = useCallback(() => {
-    if (popup && !popup.window.closed) popup.window.close();
+    if (popup && !popup.popup.closed) popup.popup.close();
     setPopup(null);
   }, [popup]);
 
@@ -30,21 +45,11 @@ export default function useOpenThreadDetails(thread: Thread | undefined) {
     event?.stopPropagation();
     if (!thread) return;
 
-    const newPopup = window.open(
-      '',
-      '_blank',
-      popupFeatures,
-    );
-    if (!newPopup) return;
-
-    newPopup.document.title = `${Thread.getFormattedTime(thread)} - ${thread.name}`;
-    const container = newPopup.document.createElement('div');
-    newPopup.document.body.replaceChildren(container);
-    setPopup({ window: newPopup, container });
+    setPopup(openThreadDetailsPopup(thread));
   }, [thread]);
 
   const WindowComponent = thread && popup ? (
-    <ThreadDetailsPopup popup={popup.window} container={popup.container} onClose={close}>
+    <ThreadDetailsPopup popup={popup.popup} container={popup.container} onClose={close}>
       <ThreadDetailsWindow thread={thread} />
     </ThreadDetailsPopup>
   ) : null;

--- a/src/components/ThreadsOverview/ThreadOverviewItem.tsx
+++ b/src/components/ThreadsOverview/ThreadOverviewItem.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import HoverPopup from '../common/HoverPopup';
 import Thread from '../../types/Thread';
 import ThreadStatus from '../../types/ThreadStatus';
-import useOpenThreadDetails from '../ThreadDetails/useOpenThreadDetails';
 
 interface Props {
   thread: Thread | undefined;
   isMatchingStackFilter: boolean;
   stackPreviewLines: number;
+  onOpenThreadDetails: (thread: Thread) => void;
 }
 
 const getClassName = (isMatchingStackFilter: boolean, status: ThreadStatus) => {
@@ -56,8 +56,8 @@ const ThreadsOverviewItem: React.FC<Props> = ({
   thread,
   isMatchingStackFilter,
   stackPreviewLines,
+  onOpenThreadDetails,
 }) => {
-  const { open, WindowComponent } = useOpenThreadDetails(thread);
   if (!thread) {
     return <td className="unknown" aria-label="Unknown thread" />;
   }
@@ -65,14 +65,11 @@ const ThreadsOverviewItem: React.FC<Props> = ({
   const className = getClassName(isMatchingStackFilter, thread.status);
 
   return (
-    <>
-      <td className={className} onClick={open}>
-        <HoverPopup content={renderStackPopupContent(thread, stackPreviewLines)}>
-          {thread.stackTrace[0]}
-        </HoverPopup>
-      </td>
-      {WindowComponent}
-    </>
+    <td className={className} onClick={() => onOpenThreadDetails(thread)}>
+      <HoverPopup renderContent={() => renderStackPopupContent(thread, stackPreviewLines)}>
+        {thread.stackTrace[0]}
+      </HoverPopup>
+    </td>
   );
 };
 

--- a/src/components/ThreadsOverview/ThreadOverviewRow.tsx
+++ b/src/components/ThreadsOverview/ThreadOverviewRow.tsx
@@ -2,41 +2,39 @@ import React, { type JSX } from 'react';
 import HoverPopup from '../common/HoverPopup';
 import Thread from '../../types/Thread';
 import ThreadsOverviewItem from './ThreadOverviewItem';
+import { ThreadOverviewDataRow } from './threadsOverviewRows';
 
 interface Props {
   total: number;
-  threads: Map<number, Thread>;
+  row: ThreadOverviewDataRow;
   matchingStackFilter: Set<number>;
   stackPreviewLines: number;
+  onOpenThreadDetails: (thread: Thread) => void;
 }
 
 export default class ThreadOverviewRow extends React.PureComponent<Props> {
   public override render(): JSX.Element {
     const {
-      total, threads, matchingStackFilter, stackPreviewLines,
+      total, row, matchingStackFilter, stackPreviewLines, onOpenThreadDetails,
     } = this.props;
-
-    const threadsPadded: (Thread | undefined)[] = [];
-    for (let i = 0; i < total; i++) {
-      threadsPadded[i] = threads.get(i);
-    }
-
-    const firstThread = threadsPadded.find((thread) => thread !== undefined);
-    const threadName = firstThread ? firstThread.name : '';
 
     return (
       <tr>
         <td className="name">
-          <HoverPopup content={threadName}>{threadName}</HoverPopup>
+          <HoverPopup content={row.name}>{row.name}</HoverPopup>
         </td>
-        {threadsPadded.map((thread, index) => (
-          <ThreadsOverviewItem
-            key={thread ? thread.uniqueId : `undefined_${index}`}
-            thread={thread}
-            isMatchingStackFilter={thread ? matchingStackFilter.has(thread.uniqueId) : false}
-            stackPreviewLines={stackPreviewLines}
-          />
-        ))}
+        {Array.from({ length: total }, (_, dumpIndex) => {
+          const thread = row.threadsByDump.get(dumpIndex);
+          return (
+            <ThreadsOverviewItem
+              key={thread ? thread.uniqueId : `undefined_${dumpIndex}`}
+              thread={thread}
+              isMatchingStackFilter={thread ? matchingStackFilter.has(thread.uniqueId) : false}
+              stackPreviewLines={stackPreviewLines}
+              onOpenThreadDetails={onOpenThreadDetails}
+            />
+          );
+        })}
       </tr>
     );
   }

--- a/src/components/ThreadsOverview/ThreadsOverviewFilteringSummary.test.tsx
+++ b/src/components/ThreadsOverview/ThreadsOverviewFilteringSummary.test.tsx
@@ -1,8 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import ThreadsOverviewFilteringSummary from './ThreadsOverviewFilteringSummary';
 import Thread from '../../types/Thread';
+import { ThreadOverviewDataRow } from './threadsOverviewRows';
 
 const thread = {} as Thread;
+
+const createRow = (id: number, threadCount: number): ThreadOverviewDataRow => ({
+  id,
+  name: `thread-${id}`,
+  threadsByDump: new Map(Array.from({ length: threadCount }, (_, index) => [index, thread])),
+});
 
 describe('ThreadsOverviewFilteringSummary', () => {
   it('shows only the row metric when only thread name filters are active', () => {
@@ -10,9 +17,7 @@ describe('ThreadsOverviewFilteringSummary', () => {
       <ThreadsOverviewFilteringSummary
         isFilteredByStack={false}
         threadsNumber={4}
-        threadDumps={[
-          new Map([[1, thread], [2, thread]]),
-        ]}
+        rows={[createRow(1, 2)]}
         matchingStackFilter={new Set()}
       />,
     );
@@ -26,10 +31,7 @@ describe('ThreadsOverviewFilteringSummary', () => {
       <ThreadsOverviewFilteringSummary
         isFilteredByStack
         threadsNumber={2}
-        threadDumps={[
-          new Map([[1, thread], [2, thread]]),
-          new Map([[3, thread]]),
-        ]}
+        rows={[createRow(1, 2), createRow(2, 1)]}
         matchingStackFilter={new Set([1, 2])}
       />,
     );
@@ -43,10 +45,7 @@ describe('ThreadsOverviewFilteringSummary', () => {
       <ThreadsOverviewFilteringSummary
         isFilteredByStack
         threadsNumber={4}
-        threadDumps={[
-          new Map([[1, thread], [2, thread]]),
-          new Map([[3, thread]]),
-        ]}
+        rows={[createRow(1, 2), createRow(2, 1)]}
         matchingStackFilter={new Set([1, 2])}
       />,
     );
@@ -55,15 +54,25 @@ describe('ThreadsOverviewFilteringSummary', () => {
     expect(screen.getByText('Highlighting 2 of 3 thread snapshots (66.7%)')).toBeInTheDocument();
   });
 
+  it('shows zero percent when stack filtering has no matching rows', () => {
+    render(
+      <ThreadsOverviewFilteringSummary
+        isFilteredByStack
+        threadsNumber={2}
+        rows={[]}
+        matchingStackFilter={new Set()}
+      />,
+    );
+
+    expect(screen.getByText('Highlighting 0 of 0 thread snapshots (0.0%)')).toBeInTheDocument();
+  });
+
   it('does not render a summary without active filters', () => {
     render(
       <ThreadsOverviewFilteringSummary
         isFilteredByStack={false}
         threadsNumber={2}
-        threadDumps={[
-          new Map([[1, thread]]),
-          new Map([[2, thread]]),
-        ]}
+        rows={[createRow(1, 1), createRow(2, 1)]}
         matchingStackFilter={new Set()}
       />,
     );

--- a/src/components/ThreadsOverview/ThreadsOverviewFilteringSummary.tsx
+++ b/src/components/ThreadsOverview/ThreadsOverviewFilteringSummary.tsx
@@ -1,25 +1,28 @@
 import Inline from '@atlaskit/primitives/inline';
 import Text from '@atlaskit/primitives/text';
 import React, { type JSX } from 'react';
-import Thread from '../../types/Thread';
+import { ThreadOverviewDataRow } from './threadsOverviewRows';
 
 interface Props {
   isFilteredByStack: boolean;
   threadsNumber: number;
-  threadDumps: Map<number, Thread>[];
+  rows: ThreadOverviewDataRow[];
   matchingStackFilter: Set<number>;
 }
 
-const nonEmptyCounter = (sum: number, currentGroup: Map<number, Thread>): number => sum + Array.from(currentGroup.values()).length;
+const nonEmptyCounter = (sum: number, row: ThreadOverviewDataRow): number => sum + row.threadsByDump.size;
 
 export default class ThreadsOverviewFilteringSummary extends React.PureComponent<Props> {
   public override render(): JSX.Element {
     const {
-      isFilteredByStack, threadsNumber, threadDumps, matchingStackFilter,
+      isFilteredByStack, threadsNumber, rows, matchingStackFilter,
     } = this.props;
-    const matchingThreads = threadDumps.length;
+    const matchingThreads = rows.length;
     const matchingSnapshots = matchingStackFilter.size;
-    const totalSnapshots = threadDumps.reduce(nonEmptyCounter, 0);
+    const totalSnapshots = rows.reduce(nonEmptyCounter, 0);
+    const matchingSnapshotPercentage = totalSnapshots === 0
+      ? '0.0'
+      : ((matchingSnapshots / totalSnapshots) * 100).toFixed(1);
     const isFilteredByName = threadsNumber !== matchingThreads;
 
     if (!isFilteredByName && !isFilteredByStack) {
@@ -55,7 +58,7 @@ export default class ThreadsOverviewFilteringSummary extends React.PureComponent
             {totalSnapshots}
             {' '}
             thread snapshots (
-            {((matchingSnapshots / totalSnapshots) * 100).toFixed(1)}
+            {matchingSnapshotPercentage}
             %)
           </Text>
         )}

--- a/src/components/ThreadsOverview/ThreadsOverviewPage.tsx
+++ b/src/components/ThreadsOverview/ThreadsOverviewPage.tsx
@@ -15,6 +15,7 @@ import ThreadsOverviewLegend from './ThreadsOverviewLegend';
 import './ThreadsOverviewPage.css';
 import ThreadsOverviewSettings from './ThreadsOverviewSettings';
 import ThreadsOverviewTable from './ThreadsOverviewTable';
+import { createThreadOverviewRows, ThreadOverviewDataRow } from './threadsOverviewRows';
 import { WithThreadDumpsProps, withThreadDumps } from '../../common/withThreadDumps';
 
 interface State {
@@ -31,6 +32,14 @@ interface State {
 }
 
 class ThreadsOverviewPage extends PageWithSettings<WithThreadDumpsProps, State> {
+  private cachedThreadDumps: ThreadDump[] | undefined;
+
+  private cachedOverviewData: {
+    nonEmptyThreadDumps: ThreadDump[];
+    rows: ThreadOverviewDataRow[];
+    dates: (string | null)[];
+  } | undefined;
+
   public override state = {
     active: true,
     nonJvm: true,
@@ -46,12 +55,10 @@ class ThreadsOverviewPage extends PageWithSettings<WithThreadDumpsProps, State> 
   };
 
   public override render(): JSX.Element {
-    const nonEmptyThreadDumps = this.props.threadDumps.filter((dump) => dump.threads.length > 0);
-    const threadOverTime = getThreadsOverTime(nonEmptyThreadDumps);
+    const { nonEmptyThreadDumps, rows, dates } = this.getData();
     const filters: ThreadsOverviewFilters = this.state;
-    const filteredDumps = filterThreads(threadOverTime, filters);
-    const matchingStackFilter = getThreadsMatchingStackFilter(filteredDumps, filters);
-    const dates = nonEmptyThreadDumps.map((dump) => ThreadDump.getFormattedTime(dump));
+    const filteredRows = filterThreads(rows, filters);
+    const matchingStackFilter = getThreadsMatchingStackFilter(filteredRows, filters);
     const filteredByStack = isFilteredByStack(filters);
 
     if (nonEmptyThreadDumps.length === 0) {
@@ -81,27 +88,45 @@ class ThreadsOverviewPage extends PageWithSettings<WithThreadDumpsProps, State> 
 
           <ThreadsOverviewFilteringSummary
             isFilteredByStack={filteredByStack}
-            threadsNumber={threadOverTime.length}
-            threadDumps={filteredDumps}
+            threadsNumber={rows.length}
+            rows={filteredRows}
             matchingStackFilter={matchingStackFilter}
           />
 
           <ThreadsOverviewLegend />
         </section>
 
-        {filteredDumps.length === 0 ? (
-          <EmptyState />
-        ) : (
+        {filteredRows.length === 0 && <EmptyState />}
+        <div hidden={filteredRows.length === 0}>
           <ThreadsOverviewTable
             dates={dates}
-            threadDumps={filteredDumps}
+            rows={filteredRows}
             matchingStackFilter={matchingStackFilter}
             dumpColumnWidth={this.state.dumpColumnWidth}
             stackPreviewLines={this.state.stackPreviewLines}
           />
-        )}
+        </div>
       </main>
     );
+  }
+
+  private getData(): {
+    nonEmptyThreadDumps: ThreadDump[];
+    rows: ThreadOverviewDataRow[];
+    dates: (string | null)[];
+  } {
+    if (this.cachedThreadDumps === this.props.threadDumps && this.cachedOverviewData) {
+      return this.cachedOverviewData;
+    }
+
+    const nonEmptyThreadDumps = this.props.threadDumps.filter((dump) => dump.threads.length > 0);
+    this.cachedThreadDumps = this.props.threadDumps;
+    this.cachedOverviewData = {
+      nonEmptyThreadDumps,
+      rows: createThreadOverviewRows(getThreadsOverTime(nonEmptyThreadDumps)),
+      dates: nonEmptyThreadDumps.map((dump) => ThreadDump.getFormattedTime(dump)),
+    };
+    return this.cachedOverviewData;
   }
 
   private handleColumnWidthChange: React.ChangeEventHandler<HTMLInputElement> = ({ target }) => {

--- a/src/components/ThreadsOverview/ThreadsOverviewTable.story.tsx
+++ b/src/components/ThreadsOverview/ThreadsOverviewTable.story.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 import Thread from '../../types/Thread';
 import ThreadStatus from '../../types/ThreadStatus';
 import ThreadsOverviewTable from './ThreadsOverviewTable';
+import { createThreadOverviewRows } from './threadsOverviewRows';
 import './ThreadsOverviewPage.css';
 
 const createThread = (id: number, name: string, dumpIndex: number): Thread => {
@@ -29,7 +30,7 @@ const Basic = (): JSX.Element => (
     <section data-testid="three-dump-table">
       <ThreadsOverviewTable
         dates={createDates(3)}
-        threadDumps={createTableRows(3)}
+        rows={createThreadOverviewRows(createTableRows(3))}
         matchingStackFilter={new Set()}
         dumpColumnWidth={160}
         stackPreviewLines={10}
@@ -38,7 +39,7 @@ const Basic = (): JSX.Element => (
     <section data-testid="many-dump-table">
       <ThreadsOverviewTable
         dates={createDates(12)}
-        threadDumps={createTableRows(12)}
+        rows={createThreadOverviewRows(createTableRows(12))}
         matchingStackFilter={new Set()}
         dumpColumnWidth={160}
         stackPreviewLines={10}

--- a/src/components/ThreadsOverview/ThreadsOverviewTable.test.tsx
+++ b/src/components/ThreadsOverview/ThreadsOverviewTable.test.tsx
@@ -1,11 +1,33 @@
-import { render, screen } from '@testing-library/react';
+import {
+  fireEvent, render, screen,
+} from '@testing-library/react';
+import React from 'react';
 import { vi } from 'vitest';
 import Thread from '../../types/Thread';
 import ThreadStatus from '../../types/ThreadStatus';
+import { openThreadDetailsPopup } from '../ThreadDetails/useOpenThreadDetails';
 import ThreadsOverviewTable from './ThreadsOverviewTable';
+import { ThreadOverviewDataRow } from './threadsOverviewRows';
+
+vi.mock('../common/HoverPopup', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../ThreadDetails/ThreadDetailsPopup', () => ({
+  default: ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
+    <div data-testid="thread-details-popup">
+      {children}
+      <button type="button" onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+vi.mock('../ThreadDetails/ThreadDetailsWindow', () => ({
+  default: ({ thread }: { thread: Thread }) => <div data-testid={`thread-details-${thread.uniqueId}`}>{thread.name}</div>,
+}));
 
 vi.mock('../ThreadDetails/useOpenThreadDetails', () => ({
-  default: () => ({ open: vi.fn(), WindowComponent: null }),
+  openThreadDetailsPopup: vi.fn(),
 }));
 
 const createThread = (id: number, name: string, stackTrace: string[]): Thread => {
@@ -15,25 +37,38 @@ const createThread = (id: number, name: string, stackTrace: string[]): Thread =>
   return thread;
 };
 
+const createRow = (thread: Thread, threadsByDump = new Map([[0, thread]])): ThreadOverviewDataRow => ({
+  id: thread.id,
+  name: thread.name,
+  threadsByDump,
+});
+
+const table = (rows: ThreadOverviewDataRow[], dumpColumnWidth = 160) => (
+  <ThreadsOverviewTable
+    dates={['10:00:00', '10:00:05', '10:00:10']}
+    rows={rows}
+    matchingStackFilter={new Set()}
+    dumpColumnWidth={dumpColumnWidth}
+    stackPreviewLines={10}
+  />
+);
+
+const renderTable = (rows: ThreadOverviewDataRow[], dumpColumnWidth = 160) => render(
+  table(rows, dumpColumnWidth),
+);
+
 describe('ThreadsOverviewTable', () => {
+  beforeEach(() => vi.mocked(openThreadDetailsPopup).mockReset());
+
   it('uses a fixed name column and a configured minimum table width', () => {
     const thread = createThread(1, 'http-nio-8080-exec-1', ['app.Request.handle']);
-
-    const { container } = render(
-      <ThreadsOverviewTable
-        dates={['10:00:00', '10:00:05', '10:00:10']}
-        threadDumps={[
-          new Map([
-            [0, thread],
-            [1, createThread(2, 'http-nio-8080-exec-1', ['app.Request.handle'])],
-            [2, createThread(3, 'http-nio-8080-exec-1', ['app.Request.handle'])],
-          ]),
-        ]}
-        matchingStackFilter={new Set()}
-        dumpColumnWidth={160}
-        stackPreviewLines={10}
-      />,
-    );
+    const { container } = renderTable([
+      createRow(thread, new Map([
+        [0, thread],
+        [1, createThread(2, 'http-nio-8080-exec-1', ['app.Request.handle'])],
+        [2, createThread(3, 'http-nio-8080-exec-1', ['app.Request.handle'])],
+      ])),
+    ]);
 
     expect(container.querySelector('.threads-overview-name-column')).toHaveStyle({ width: '240px' });
     expect(container.querySelector('.threads-overview-table')).toHaveStyle({ minWidth: '720px' });
@@ -42,23 +77,59 @@ describe('ThreadsOverviewTable', () => {
 
   it('uses fit-columns mode when the configured minimum width is zero', () => {
     const thread = createThread(1, 'worker-1', ['app.Work.run']);
-
-    const { container } = render(
-      <ThreadsOverviewTable
-        dates={['10:00:00', '10:00:05']}
-        threadDumps={[
-          new Map([
-            [0, thread],
-            [1, createThread(2, 'worker-1', ['app.Work.run'])],
-          ]),
-        ]}
-        matchingStackFilter={new Set([thread.uniqueId])}
-        dumpColumnWidth={0}
-        stackPreviewLines={1}
-      />,
-    );
+    const { container } = renderTable([createRow(thread)], 0);
 
     expect(container.querySelector('.threads-overview-table')).toHaveClass('threads-overview-table-fit-columns');
     expect(container.querySelector('.threads-overview-table')).not.toHaveStyle({ minWidth: '560px' });
+  });
+
+  it('keeps multiple detail windows open and focuses an existing snapshot', () => {
+    const firstThread = createThread(1, 'worker-1', ['first.frame']);
+    const secondThread = createThread(2, 'worker-2', ['second.frame']);
+    const firstPopup = { closed: false, close: vi.fn(), focus: vi.fn() } as unknown as Window;
+    const secondPopup = { closed: false, close: vi.fn(), focus: vi.fn() } as unknown as Window;
+    vi.mocked(openThreadDetailsPopup)
+      .mockReturnValueOnce({ popup: firstPopup, container: document.createElement('div') })
+      .mockReturnValueOnce({ popup: secondPopup, container: document.createElement('div') });
+
+    renderTable([createRow(firstThread), createRow(secondThread)]);
+
+    fireEvent.click(screen.getByText('first.frame'));
+    fireEvent.click(screen.getByText('second.frame'));
+
+    expect(openThreadDetailsPopup).toHaveBeenCalledTimes(2);
+    expect(screen.getAllByTestId('thread-details-popup')).toHaveLength(2);
+
+    fireEvent.click(screen.getByText('first.frame'));
+
+    expect(openThreadDetailsPopup).toHaveBeenCalledTimes(2);
+    expect(firstPopup.focus).toHaveBeenCalledOnce();
+  });
+
+  it('removes only the closed detail window and closes remaining windows on unmount', () => {
+    const firstThread = createThread(1, 'worker-1', ['first.frame']);
+    const secondThread = createThread(2, 'worker-2', ['second.frame']);
+    const firstPopup = { closed: false, close: vi.fn(), focus: vi.fn() } as unknown as Window;
+    const secondPopup = { closed: false, close: vi.fn(), focus: vi.fn() } as unknown as Window;
+    vi.mocked(openThreadDetailsPopup)
+      .mockReturnValueOnce({ popup: firstPopup, container: document.createElement('div') })
+      .mockReturnValueOnce({ popup: secondPopup, container: document.createElement('div') });
+
+    const { rerender, unmount } = renderTable([createRow(firstThread), createRow(secondThread)]);
+    fireEvent.click(screen.getByText('first.frame'));
+    fireEvent.click(screen.getByText('second.frame'));
+
+    rerender(table([]));
+    expect(screen.getAllByTestId('thread-details-popup')).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[0]);
+
+    expect(screen.queryByTestId(`thread-details-${firstThread.uniqueId}`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`thread-details-${secondThread.uniqueId}`)).toBeInTheDocument();
+
+    unmount();
+
+    expect(firstPopup.close).not.toHaveBeenCalled();
+    expect(secondPopup.close).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/ThreadsOverview/ThreadsOverviewTable.tsx
+++ b/src/components/ThreadsOverview/ThreadsOverviewTable.tsx
@@ -1,20 +1,74 @@
 import React, { type JSX } from 'react';
 import HoverPopup from '../common/HoverPopup';
 import Thread from '../../types/Thread';
+import ThreadDetailsPopup from '../ThreadDetails/ThreadDetailsPopup';
+import ThreadDetailsWindow from '../ThreadDetails/ThreadDetailsWindow';
+import { openThreadDetailsPopup } from '../ThreadDetails/useOpenThreadDetails';
+import type { ThreadDetailsPopupWindow } from '../ThreadDetails/useOpenThreadDetails';
 import ThreadOverviewRow from './ThreadOverviewRow';
+import type { ThreadOverviewDataRow } from './threadsOverviewRows';
 
 interface Props {
   dates: (string | null)[];
-  threadDumps: Map<number, Thread>[];
+  rows: ThreadOverviewDataRow[];
   matchingStackFilter: Set<number>;
   dumpColumnWidth: number;
   stackPreviewLines: number;
 }
 
-export default class ThreadsOverviewTable extends React.PureComponent<Props> {
+interface OpenThreadDetails extends ThreadDetailsPopupWindow {
+  thread: Thread;
+}
+
+interface State {
+  openDetailsVersion: number;
+}
+
+export default class ThreadsOverviewTable extends React.PureComponent<Props, State> {
+  private readonly openDetails = new Map<number, OpenThreadDetails>();
+
+  private isUnmounting = false;
+
+  public constructor(props: Props) {
+    super(props);
+    this.state = { openDetailsVersion: 0 };
+  }
+
+  public override componentWillUnmount(): void {
+    this.isUnmounting = true;
+    this.openDetails.forEach(({ popup }) => {
+      if (!popup.closed) popup.close();
+    });
+    this.openDetails.clear();
+  }
+
+  private handleOpenThreadDetails = (thread: Thread): void => {
+    const existing = this.openDetails.get(thread.uniqueId);
+    if (existing && !existing.popup.closed) {
+      existing.popup.focus();
+      return;
+    }
+
+    const popup = openThreadDetailsPopup(thread);
+    if (!popup) return;
+
+    this.openDetails.set(thread.uniqueId, { thread, ...popup });
+    this.refreshOpenDetails();
+  };
+
+  private handleCloseThreadDetails = (uniqueId: number): void => {
+    this.openDetails.delete(uniqueId);
+    this.refreshOpenDetails();
+  };
+
+  private refreshOpenDetails(): void {
+    if (this.isUnmounting) return;
+    this.setState(({ openDetailsVersion }) => ({ openDetailsVersion: openDetailsVersion + 1 }));
+  }
+
   public override render(): JSX.Element {
     const {
-      dates, threadDumps, matchingStackFilter, dumpColumnWidth, stackPreviewLines,
+      dates, rows, matchingStackFilter, dumpColumnWidth, stackPreviewLines,
     } = this.props;
 
     const nameColumnWidth = 240;
@@ -50,17 +104,28 @@ export default class ThreadsOverviewTable extends React.PureComponent<Props> {
             </tr>
           </thead>
           <tbody>
-            {threadDumps.map((threads) => (
+            {rows.map((row) => (
               <ThreadOverviewRow
-                key={(threads.values().next().value as Thread).uniqueId}
+                key={row.id}
                 total={dates.length}
-                threads={threads}
+                row={row}
                 matchingStackFilter={matchingStackFilter}
                 stackPreviewLines={stackPreviewLines}
+                onOpenThreadDetails={this.handleOpenThreadDetails}
               />
             ))}
           </tbody>
         </table>
+        {Array.from(this.openDetails.values()).map(({ thread, popup, container }) => (
+          <ThreadDetailsPopup
+            key={thread.uniqueId}
+            popup={popup}
+            container={container}
+            onClose={() => this.handleCloseThreadDetails(thread.uniqueId)}
+          >
+            <ThreadDetailsWindow thread={thread} />
+          </ThreadDetailsPopup>
+        ))}
       </div>
     );
   }

--- a/src/components/ThreadsOverview/threadsOverviewFilters.test.ts
+++ b/src/components/ThreadsOverview/threadsOverviewFilters.test.ts
@@ -6,6 +6,7 @@ import {
   isFilteredByStack,
   ThreadsOverviewFilters,
 } from './threadsOverviewFilters';
+import { ThreadOverviewDataRow } from './threadsOverviewRows';
 
 const defaultFilters = (): ThreadsOverviewFilters => ({
   active: false,
@@ -27,24 +28,35 @@ const createThread = (id: number, name: string, stackTrace: string[] = [], cpuUs
   return thread;
 };
 
+const createRow = (thread: Thread): ThreadOverviewDataRow => ({
+  id: thread.id,
+  name: thread.name,
+  threadsByDump: new Map([[0, thread]]),
+});
+
 describe('threadsOverviewFilters', () => {
   it('filters thread rows by name, CPU usage, and JVM classification', () => {
     const httpThread = createThread(1, 'http-nio-8080-exec-1', ['app.Request.handle'], '12.50');
     const jvmThread = createThread(2, 'GC Daemon', ['java.lang.System.gc']);
     const workerThread = createThread(3, 'worker-1', ['app.Work.run']);
     const rows = [
-      new Map([[0, httpThread]]),
-      new Map([[0, jvmThread]]),
-      new Map([[0, workerThread]]),
+      createRow(httpThread),
+      createRow(jvmThread),
+      createRow(workerThread),
     ];
 
-    expect(filterThreads(rows, { ...defaultFilters(), tomcat: true, usingCpu: true })).toEqual([rows[0]]);
-    expect(filterThreads(rows, { ...defaultFilters(), nonJvm: true })).toEqual([rows[0], rows[2]]);
-    expect(filterThreads(rows, { ...defaultFilters(), nameFilter: '^worker' })).toEqual([rows[2]]);
+    const cpuTomcatRows = filterThreads(rows, { ...defaultFilters(), tomcat: true, usingCpu: true });
+    const nonJvmRows = filterThreads(rows, { ...defaultFilters(), nonJvm: true });
+    const workerRows = filterThreads(rows, { ...defaultFilters(), nameFilter: '^worker' });
+
+    expect(cpuTomcatRows).toEqual([rows[0]]);
+    expect(cpuTomcatRows[0]).toBe(rows[0]);
+    expect(nonJvmRows).toEqual([rows[0], rows[2]]);
+    expect(workerRows).toEqual([rows[2]]);
   });
 
   it('ignores an invalid name regular expression', () => {
-    const rows = [new Map([[0, createThread(1, 'worker-1')]])];
+    const rows = [createRow(createThread(1, 'worker-1'))];
 
     expect(filterThreads(rows, { ...defaultFilters(), nameFilter: '[' })).toEqual(rows);
   });
@@ -56,8 +68,8 @@ describe('threadsOverviewFilters', () => {
     ]);
     const luceneOnlyThread = createThread(2, 'index', ['org.apache.lucene.index.Writer']);
     const rows = [
-      new Map([[0, luceneDatabaseThread]]),
-      new Map([[0, luceneOnlyThread]]),
+      createRow(luceneDatabaseThread),
+      createRow(luceneOnlyThread),
     ];
     const filters = { ...defaultFilters(), lucene: true, database: true };
 

--- a/src/components/ThreadsOverview/threadsOverviewFilters.ts
+++ b/src/components/ThreadsOverview/threadsOverviewFilters.ts
@@ -1,5 +1,5 @@
 import { isActiveOverTime } from '../../common/threadFilters';
-import Thread from '../../types/Thread';
+import { ThreadOverviewDataRow } from './threadsOverviewRows';
 
 export interface ThreadsOverviewFilters {
   active: boolean;
@@ -18,12 +18,12 @@ const tomcatRegex = /^https?-.*exec/;
 const luceneRegex = /org\.apache\.lucene/;
 const databaseRegex = /database|sql|query|jdbc|jooq|postgres|mysql|oracle|c3p0/i;
 
-const matchesName = (threads: Map<number, Thread>, regex: RegExp): boolean => Array.from(
-  threads.values(),
+const matchesName = (row: ThreadOverviewDataRow, regex: RegExp): boolean => Array.from(
+  row.threadsByDump.values(),
 ).some((thread) => regex.test(thread.name));
 
-const isUsingCpu = (threads: Map<number, Thread>): boolean => Array.from(
-  threads.values(),
+const isUsingCpu = (row: ThreadOverviewDataRow): boolean => Array.from(
+  row.threadsByDump.values(),
 ).some((thread) => parseFloat(thread.cpuUsage) >= 10);
 
 const toOptionalRegex = (value: string): RegExp | undefined => {
@@ -39,18 +39,18 @@ const toOptionalRegex = (value: string): RegExp | undefined => {
 };
 
 export const filterThreads = (
-  threadDumps: Map<number, Thread>[],
+  rows: ThreadOverviewDataRow[],
   filters: ThreadsOverviewFilters,
-): Map<number, Thread>[] => {
+): ThreadOverviewDataRow[] => {
   const nameRegex = toOptionalRegex(filters.nameFilter);
 
-  return threadDumps
-    .filter((threads) => !filters.active || isActiveOverTime(threads))
-    .filter((threads) => !filters.usingCpu || isUsingCpu(threads))
-    .filter((threads) => !filters.nonJvm || !matchesName(threads, jvmRegex))
-    .filter((threads) => !filters.tomcat || matchesName(threads, tomcatRegex))
-    .filter((threads) => !filters.nonTomcat || !matchesName(threads, tomcatRegex))
-    .filter((threads) => !nameRegex || matchesName(threads, nameRegex));
+  return rows
+    .filter((row) => !filters.active || isActiveOverTime(row.threadsByDump))
+    .filter((row) => !filters.usingCpu || isUsingCpu(row))
+    .filter((row) => !filters.nonJvm || !matchesName(row, jvmRegex))
+    .filter((row) => !filters.tomcat || matchesName(row, tomcatRegex))
+    .filter((row) => !filters.nonTomcat || !matchesName(row, tomcatRegex))
+    .filter((row) => !nameRegex || matchesName(row, nameRegex));
 };
 
 const getStackTraceFilters = (filters: ThreadsOverviewFilters): RegExp[] => {
@@ -71,7 +71,7 @@ const getStackTraceFilters = (filters: ThreadsOverviewFilters): RegExp[] => {
 };
 
 export const getThreadsMatchingStackFilter = (
-  threadDumps: Map<number, Thread>[],
+  rows: ThreadOverviewDataRow[],
   filters: ThreadsOverviewFilters,
 ): Set<number> => {
   const stackTraceFilters = getStackTraceFilters(filters);
@@ -80,8 +80,8 @@ export const getThreadsMatchingStackFilter = (
   }
 
   return new Set(
-    threadDumps
-      .flatMap((threads) => Array.from(threads.values()))
+    rows
+      .flatMap((row) => Array.from(row.threadsByDump.values()))
       .filter((thread) => stackTraceFilters.every((filter) => thread.stackTrace.some((line) => filter.test(line))))
       .map((thread) => thread.uniqueId),
   );

--- a/src/components/ThreadsOverview/threadsOverviewRows.test.ts
+++ b/src/components/ThreadsOverview/threadsOverviewRows.test.ts
@@ -1,0 +1,37 @@
+import getThreadsOverTime from '../../common/getThreadsOverTime';
+import ThreadDump from '../../types/ThreadDump';
+import Thread from '../../types/Thread';
+import { createThreadOverviewRows } from './threadsOverviewRows';
+
+const createThread = (id: number, name: string): Thread => new Thread(id, name);
+
+describe('createThreadOverviewRows', () => {
+  it('preserves grouped row order and sparse dump maps', () => {
+    const alphaFirst = createThread(3, 'alpha');
+    const alphaSecond = createThread(1, 'alpha');
+    const beta = createThread(2, 'beta');
+    const alphaFirstDumps = new Map([[1, alphaFirst]]);
+    const betaDumps = new Map([[0, beta]]);
+    const alphaSecondDumps = new Map([[2, alphaSecond]]);
+
+    const rows = createThreadOverviewRows([betaDumps, alphaFirstDumps, alphaSecondDumps]);
+
+    expect(rows.map((row) => [row.id, row.name])).toEqual([
+      [2, 'beta'],
+      [3, 'alpha'],
+      [1, 'alpha'],
+    ]);
+    expect(rows[1].threadsByDump).toBe(alphaFirstDumps);
+    expect(rows[2].threadsByDump).toBe(alphaSecondDumps);
+    expect(rows[1].threadsByDump.get(0)).toBeUndefined();
+  });
+
+  it('orders same-name thread groups by ID', () => {
+    const dump = new ThreadDump(0);
+    dump.threads.push(createThread(3, 'worker'), createThread(1, 'worker'));
+
+    const groups = getThreadsOverTime([dump]);
+
+    expect(groups.map((threads) => threads.values().next().value?.id)).toEqual([1, 3]);
+  });
+});

--- a/src/components/ThreadsOverview/threadsOverviewRows.ts
+++ b/src/components/ThreadsOverview/threadsOverviewRows.ts
@@ -1,0 +1,23 @@
+import Thread from '../../types/Thread';
+
+export interface ThreadOverviewDataRow {
+  readonly id: number;
+  readonly name: string;
+  readonly threadsByDump: ReadonlyMap<number, Thread>;
+}
+
+export const createThreadOverviewRows = (
+  threadGroups: Map<number, Thread>[],
+): ThreadOverviewDataRow[] => threadGroups
+  .map((threadsByDump) => {
+    const firstThread = threadsByDump.values().next().value;
+    if (!firstThread) {
+      throw new Error('Thread overview rows must contain at least one thread');
+    }
+
+    return {
+      id: firstThread.id,
+      name: firstThread.name,
+      threadsByDump,
+    };
+  });

--- a/src/components/common/HoverPopup.test.tsx
+++ b/src/components/common/HoverPopup.test.tsx
@@ -60,4 +60,28 @@ describe('HoverPopup', () => {
 
     expect(screen.getByText('Thread details')).toBeVisible();
   });
+
+  it('evaluates lazy content only after the popup opens', () => {
+    const renderContent = vi.fn(() => 'Stack preview');
+    const { rerender } = render(
+      <HoverPopup renderContent={renderContent}>
+        <button type="button">Trigger</button>
+      </HoverPopup>,
+    );
+    const trigger = screen.getByText('Trigger').parentElement as HTMLDivElement;
+
+    expect(renderContent).not.toHaveBeenCalled();
+
+    rerender(
+      <HoverPopup renderContent={renderContent}>
+        <button type="button">Trigger</button>
+      </HoverPopup>,
+    );
+    expect(renderContent).not.toHaveBeenCalled();
+
+    fireEvent.mouseEnter(trigger);
+
+    expect(renderContent).toHaveBeenCalledOnce();
+    expect(screen.getByText('Stack preview')).toBeVisible();
+  });
 });

--- a/src/components/common/HoverPopup.tsx
+++ b/src/components/common/HoverPopup.tsx
@@ -4,15 +4,21 @@ import React, {
 } from 'react';
 import PopupContent from './PopupContent';
 
-interface Props {
+type Props = {
   children: React.ReactNode;
   content: React.ReactNode;
-}
+  renderContent?: never;
+} | {
+  children: React.ReactNode;
+  content?: never;
+  renderContent: () => React.ReactNode;
+};
 
 const CLOSE_DELAY_MS = 100;
 
 // Atlaskit Popup owns placement; this adapter supplies reusable hover open/close behavior for React triggers.
-const HoverPopup: React.FC<Props> = ({ children, content }) => {
+const HoverPopup: React.FC<Props> = ({ children, ...props }) => {
+  const { content, renderContent: lazyContent } = props;
   const [isOpen, setIsOpen] = useState(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -36,8 +42,8 @@ const HoverPopup: React.FC<Props> = ({ children, content }) => {
   useEffect(() => cancelClose, [cancelClose]);
 
   const renderContent = useCallback(
-    () => <PopupContent>{content}</PopupContent>,
-    [content],
+    () => <PopupContent>{isOpen && lazyContent ? lazyContent() : content}</PopupContent>,
+    [content, isOpen, lazyContent],
   );
 
   const renderTrigger = useCallback(


### PR DESCRIPTION
- introduce sparse, stable overview row data
- keep multiple thread detail windows alive across filtering
- lazily render stack preview popup content
- add deterministic row ordering and focused regression coverage

Refactors to unblock #114